### PR TITLE
correct url in README for githubteacher

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A project based learning activity for people who are getting started with Git and GitHub.
 
-You can play the game at: http://githubschool.github.io/github-games/
+You can play the game at: https://githubteacher.github.io/github-games/
 
 Here is how you play the game:
 1. Press the space bar to get started.


### PR DESCRIPTION
The previous readme included the `githubschool` url, this should be fixed since my fork is different.