### PR TITLE
update url to point to githubteacher

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A project based learning activity for people who are getting started with Git and GitHub.
 
-You can play the game at: http://githubschool.github.io/github-games/
+You can play the game at: http://githubteacher.github.io/github-games/
 
 >> _*SUPPORTED BROWSERS*: Chrome, Firefox, Safari, Opera and IE9+_
 


### PR DESCRIPTION
This PR just updates the URL to point to `githubteacher` instead of `githubschool` for my GitHub Pages site. 